### PR TITLE
moves everything to an sbt style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# sbt artifacts
+target
+*.class

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ example uses, and possibly a RISK simulator.
 
 To try out some examples, do
 
-    $ ./run.sh
+    $ sbt console
 
     scala> runBayesianCoin(5)
 

--- a/boot.scala
+++ b/boot.scala
@@ -1,2 +1,0 @@
-import Distribution._
-import Examples._

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,9 @@
+name := "probability-monad" // insert clever name here
+
+scalaVersion := "2.10.2"
+
+crossScalaVersions := Seq("2.9.2", "2.9.3", "2.10.2")
+
+initialCommands := """
+                |import probability_monad.Distribution._
+                |import probability_monad.Examples._""".stripMargin('|')

--- a/project/built.properties
+++ b/project/built.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.3

--- a/src/main/scala/probability-monad/Distribution.scala
+++ b/src/main/scala/probability-monad/Distribution.scala
@@ -1,3 +1,5 @@
+package probability_monad
+
 import java.math.MathContext
 import scala.annotation.tailrec
 import scala.math.BigDecimal
@@ -148,7 +150,7 @@ trait Distribution[A] {
 
   def plotBucketedHist(buckets: Int = 20)(implicit ord: Ordering[A], frac: Fractional[A]) = {
     val data = this.sample(N).toList.sorted
-    val min = data.first
+    val min = data.head
     val max = data.last
     val (outerMin, outerMax, width, nbuckets) = findBucketWidth(frac.toDouble(min), frac.toDouble(max), buckets)
     val rm = BigDecimal.RoundingMode.HALF_UP

--- a/src/main/scala/probability-monad/Examples.scala
+++ b/src/main/scala/probability-monad/Examples.scala
@@ -1,3 +1,5 @@
+package probability_monad
+
 object Examples {
   import Distribution._
 


### PR DESCRIPTION
## motivation

Projects are more accessible if they use standard tooling and organization.  For better or for worse, sbt is the standard in building projects in scala, and so it's much easier for people to use probability-monad if it interoperates with sbt.
## implementation

added a build.sbt file, chose a scalaVersion, moved everything to a namespace, and moved the boot.scala code into an initialCommands setting in sbt.
## feedback

I just guessed on most of these default settings.  If you don't like any or all of them, let's chat and work out something amenable.  I think this project is awesome, and I'd be happy to contribute to other things too.  This just seemed like an obvious place which might be useful.  If you decide you absolutely don't want sbt, we can chat about that too.
