### PR TITLE
use aggregate to fold results in parallel

### DIFF
--- a/src/main/scala/probability-monad/Distribution.scala
+++ b/src/main/scala/probability-monad/Distribution.scala
@@ -92,7 +92,7 @@ trait Distribution[A] {
   // NB: Expected value only makes sense for real-valued distributions. If you want to find the expected
   // value of a die roll, for example, you have to do die.map(_.toDouble).ev.
   def ev(implicit toDouble: A <:< Double): Double = {
-    (0 until N).par.map(i => toDouble(self.get) / N).sum
+    (0 until N).par.map(_ => toDouble(self.get)).aggregate(0d)(_ + _ / N, _ + _)
   }
 
   def mean(implicit toDouble: A <:< Double): Double = ev


### PR DESCRIPTION
Discovered this function I never used before with sequential collections to compute sum in parallel and lazily. I looked at foldLeft at first, but it was sequential in ParSeq. It passes my local tests and has same performance.