### PR TITLE
Bump Scala version to 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "probability-monad" // insert clever name here
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.12.0"
 
-crossScalaVersions := Seq("2.10.3", "2.11.4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0")
 
 scalacOptions ++= Seq("-Xfatal-warnings", "-deprecation")
 

--- a/src/main/scala/probability-monad/Examples.scala
+++ b/src/main/scala/probability-monad/Examples.scala
@@ -212,11 +212,11 @@ object Examples {
    * Simpson's Paradox
    */
 
-  abstract class Party
+  sealed abstract class Party
   case object Democrat extends Party
   case object Republican extends Party
 
-  abstract class State
+  sealed abstract class State
   case object North extends State
   case object South extends State
 


### PR DESCRIPTION
The main purpose of this PR is to eventually get 2.12 artifacts in the repo. Please let me know if you want to keep `scalaVersion` at 2.11 for now.