### PR TITLE
Make Distribution.get public

### DIFF
--- a/src/main/scala/probability-monad/Distribution.scala
+++ b/src/main/scala/probability-monad/Distribution.scala
@@ -137,6 +137,7 @@ trait Distribution[A] {
   }
 
   def sample(n: Int = N): List[A] = List.fill(n)(self.get)
+  def sampleSingle(): A = self.get
 
   def samplePar(n: Int = N): ParSeq[A] = (0 until N).par.map(i => self.get)
 


### PR DESCRIPTION
This allows to avoid List creation using `sample` if only one sample is needed. Does it have any downsides to use `get` directly?

Or would it be better to provide an extra method like `singleSample` or similar?
